### PR TITLE
Fix parsing of indented comments

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -248,7 +248,7 @@ func (y *yamlReader) NextLine() (line string, err error) {
 		if err != nil {
 			return
 		}
-		if strings.HasPrefix(line, "---") || strings.HasPrefix(line, "#") {
+		if strings.HasPrefix(line, "---") || strings.HasPrefix(strings.TrimLeft(line, "\t "), "#") {
 			continue
 		}
 


### PR DESCRIPTION
This fixes an issue where an indented comment was causing the YAML parser to fail. Instead of skipping the line (as shown on line 252), the parser would instead attempt to extract a key value pair.